### PR TITLE
Split Prometheus registry into Gatherer and Registerer interfaces

### DIFF
--- a/starter/internal/metric/prometheus_server.go
+++ b/starter/internal/metric/prometheus_server.go
@@ -12,20 +12,20 @@ import (
 )
 
 type PrometheusServer struct {
-	registry *prometheus.Registry
+	gatherer prometheus.Gatherer
 	host     PrometheusHost
 	port     PrometheusPort
 	path     PrometheusPath
 }
 
-func NewPrometheusServer(registry *prometheus.Registry, host PrometheusHost, port PrometheusPort, path PrometheusPath) (*PrometheusServer, error) {
+func NewPrometheusServer(gatherer prometheus.Gatherer, host PrometheusHost, port PrometheusPort, path PrometheusPath) (*PrometheusServer, error) {
 	// Validate port range
 	if port < 0 || port > 65535 {
 		return nil, errors.New("invalid port: must be between 0 and 65535")
 	}
 
 	// Initialize and return the exporter
-	return &PrometheusServer{registry: registry, host: host, port: port, path: path}, nil
+	return &PrometheusServer{gatherer: gatherer, host: host, port: port, path: path}, nil
 }
 
 func (ps *PrometheusServer) Addr() string {
@@ -67,5 +67,5 @@ func (ps *PrometheusServer) Start(ctx context.Context) (func(), error) {
 }
 
 func (ps *PrometheusServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	promhttp.HandlerFor(ps.registry, promhttp.HandlerOpts{}).ServeHTTP(w, req)
+	promhttp.HandlerFor(ps.gatherer, promhttp.HandlerOpts{}).ServeHTTP(w, req)
 }

--- a/starter/option.go
+++ b/starter/option.go
@@ -9,10 +9,11 @@ import (
 )
 
 type option struct {
-	serviceName        *string
-	traceExporters     *intltrace.Exporters
-	metricExporters    *intlmetric.Exporters
-	prometheusRegistry *prometheus.Registry
+	serviceName          *string
+	traceExporters       *intltrace.Exporters
+	metricExporters      *intlmetric.Exporters
+	prometheusGatherer   prometheus.Gatherer
+	prometheusRegisterer prometheus.Registerer
 }
 
 func newOption(opts ...func(c *option)) *option {
@@ -36,8 +37,12 @@ func (o *option) MetricExporters() (intlmetric.Exporters, bool) {
 	return ptr.To(o.metricExporters), o.metricExporters != nil
 }
 
-func (o *option) PrometheusRegistry() (*prometheus.Registry, bool) {
-	return o.prometheusRegistry, o.prometheusRegistry != nil
+func (o *option) PrometheusGatherer() (prometheus.Gatherer, bool) {
+	return o.prometheusGatherer, o.prometheusGatherer != nil
+}
+
+func (o *option) PrometheusRegisterer() (prometheus.Registerer, bool) {
+	return o.prometheusRegisterer, o.prometheusRegisterer != nil
 }
 
 func WithServiceName(serviceName string) func(opt *option) {
@@ -62,8 +67,14 @@ func WithMetricsExporter(exporter intlmetric.Exporter) func(opt *option) {
 	}
 }
 
-func WithPrometheusRegistry(promRegistry *prometheus.Registry) func(opt *option) {
+func WithPrometheusGatherer(gatherer prometheus.Gatherer) func(opt *option) {
 	return func(opt *option) {
-		opt.prometheusRegistry = promRegistry
+		opt.prometheusGatherer = gatherer
+	}
+}
+
+func WithPrometheusRegisterer(registerer prometheus.Registerer) func(opt *option) {
+	return func(opt *option) {
+		opt.prometheusRegisterer = registerer
 	}
 }


### PR DESCRIPTION
Split registry functionality into `Gatherer` for metric collection and `Registerer` for metric registration